### PR TITLE
Manual units selection in preferences

### DIFF
--- a/nightscout@jeroen.wtf/extension.js
+++ b/nightscout@jeroen.wtf/extension.js
@@ -48,6 +48,7 @@ let NOTIFICATION_OUT_OF_RANGE = true;
 let NOTIFICATION_STALE_DATA = true;
 let NOTIFICATION_RAPIDLY_CHANGES = true;
 let NOTIFICATION_URGENCY_LEVEL = 2;
+let UNITS_SELECTION = "auto";
 let UNITS = "mg/dl";
 
 // NS thresholds
@@ -347,6 +348,9 @@ const Indicator = GObject.registerClass(
       NOTIFICATION_URGENCY_LEVEL = settings.get_int(
         "notification-urgency-level",
       );
+
+      UNITS_SELECTION = settings.get_string("units-selection");
+      this._setUnitsFromSelection();
     }
 
     async _fetchServerSettings() {
@@ -359,7 +363,10 @@ const Indicator = GObject.registerClass(
 
         const { units, thresholds } = data.settings;
 
-        UNITS = ["mmol", "mmol/L"].includes(units) ? "mmol/L" : "mg/dl";
+        // Only use server units if user hasn't manually selected units
+        if (UNITS_SELECTION === "auto") {
+          UNITS = ["mmol", "mmol/L"].includes(units) ? "mmol/L" : "mg/dl";
+        }
 
         THRESHOLD_BG_HIGH = this._convertBgValue(thresholds.bgHigh);
         THRESHOLD_BG_TARGET_TOP = this._convertBgValue(thresholds.bgTargetTop);
@@ -730,6 +737,17 @@ const Indicator = GObject.registerClass(
       if (this._sourceId) {
         GLib.Source.remove(this._sourceId);
         this._sourceId = null;
+      }
+    }
+
+    _setUnitsFromSelection() {
+      if (UNITS_SELECTION === "auto") {
+        // Units will be set from server in _fetchServerSettings
+        return;
+      } else if (UNITS_SELECTION === "mg/dl") {
+        UNITS = "mg/dl";
+      } else if (UNITS_SELECTION === "mmol/L") {
+        UNITS = "mmol/L";
       }
     }
 

--- a/nightscout@jeroen.wtf/prefs.js
+++ b/nightscout@jeroen.wtf/prefs.js
@@ -166,6 +166,40 @@ export default class NightscoutPreferences extends ExtensionPreferences {
       Gio.SettingsBindFlags.DEFAULT,
     );
 
+    const unitsGroup = new Adw.PreferencesGroup({
+      title: _("Units"),
+    });
+    page.add(unitsGroup);
+
+    let unitsList = new Gtk.StringList();
+    unitsList.append(_("Automatic (from server)"));
+    unitsList.append(_("mg/dL"));
+    unitsList.append(_("mmol/L"));
+
+    const unitsSelectionRow = new Adw.ComboRow({
+      title: _("Glucose units"),
+      subtitle: _(
+        "Choose units for displaying glucose values. Automatic uses server settings.",
+      ),
+      model: unitsList,
+    });
+    unitsGroup.add(unitsSelectionRow);
+
+    // Map string values to indices for the combo box
+    const unitsMap = ["auto", "mg/dl", "mmol/L"];
+    const currentUnits = window._settings.get_string("units-selection");
+    const currentIndex = unitsMap.indexOf(currentUnits);
+    if (currentIndex >= 0) {
+      unitsSelectionRow.set_selected(currentIndex);
+    }
+
+    unitsSelectionRow.connect("notify::selected", () => {
+      const selectedIndex = unitsSelectionRow.get_selected();
+      if (selectedIndex >= 0 && selectedIndex < unitsMap.length) {
+        window._settings.set_string("units-selection", unitsMap[selectedIndex]);
+      }
+    });
+
     const notificationsGroup = new Adw.PreferencesGroup({
       title: _("Notifications"),
     });

--- a/nightscout@jeroen.wtf/schemas/org.gnome.shell.extensions.nightscout.gschema.xml
+++ b/nightscout@jeroen.wtf/schemas/org.gnome.shell.extensions.nightscout.gschema.xml
@@ -84,5 +84,11 @@
       <summary>Seconds to timeout</summary>
       <description>The amount of time in seconds to declare that a call timed out (your server didn't answer)</description>
     </key>
+
+    <key name="units-selection" type="s">
+      <default>'auto'</default>
+      <summary>Units selection</summary>
+      <description>Units to display glucose values in. 'auto' uses server settings, 'mg/dl' or 'mmol/L' for manual selection</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Manual units selection in preferences (mg/dL, mmol/L, or automatic from server)

https://github.com/jeroenwtf/gnome-nightscout/issues/5